### PR TITLE
Print out useful error messages for each found issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,17 +101,27 @@ const performCompilation = (ts: TS, config:ParsedCommandLine) => {
   const diagnostics = ts.sortAndDeduplicateDiagnostics(all)
 
   diagnostics.forEach(d => {
-    const file = d.file?.fileName || "<unknown file>"
+    if (!d.file) {
+      // not very useful without file/line info
+      return
+    }
+
+    const file = d.file.fileName || "<unknown file>"
     const start = d.start || 0
     const end = start + (d.length || 0)
-    const line = d.file?.getLineAndCharacterOfPosition(start)
-    const message = (d.messageText as DiagnosticMessageChain) ? 
-      (d.messageText as DiagnosticMessageChain).messageText :
-      d.messageText
-    d.relatedInformation?.forEach(r => {
+    const line = d.file.getLineAndCharacterOfPosition(start)
+
+    let message: string = ""
+    if (d.messageText as DiagnosticMessageChain) {
+      message = (d.messageText as DiagnosticMessageChain).messageText
+    } else {
+      message = (d.messageText as string)
+    }
+
+    (d.relatedInformation || []).forEach(r => {
       console.warn("Related: ", r.messageText)
     })
-    console.warn(`${file}:${line?.line || 0}:${line?.character || 0}\n${message}`)
+    console.warn(`${file}:${line.line || 0}:${line.character || 0}\n${message}`)
   })
 
   upload(diagnostics.slice())


### PR DESCRIPTION
Sometimes errors crop up in this action that aren't visible in VSCode, and are not part of eslint or any of the stuff we run locally on a regular basis.

When we do get an error, it looks like this:

```
Using local typescript@3.9.9
Found 1 errors!
::error::Found 1 errors!
```

This change adds some additional information logged out for each issue found:

```
Using local typescript@3.9.9
/Users/ben/projects/spin/spin-mobile/app/components/GiftBoxButton.tsx:22:26
Expected 3 arguments, but got 2.
Found 1 errors!
::error::Found 1 errors!
```

(Note that the line number may be off by a few lines if the file in question has any // @ts-ignore lines in it, as these are, well, ignored.)